### PR TITLE
CIテスト時にエラーログが出ている不具合を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
+    "postinstall": "touch .env",
     "flow": "flow",
     "type": "npm run flow",
     "lint": "eslint src",


### PR DESCRIPTION
```
{ Error: ENOENT: no such file or directory, open '.env'
    at Error (native)
    at Object.fs.openSync (fs.js:634:18)
    at Object.fs.readFileSync (fs.js:502:33)
    at Object.module.exports.config (/home/travis/build/namikingsoft/flowtype-sandbox/node_modules/dotenv/lib/main.js:30:37)
    at Object.<anonymous> (bootstrap.js:4:8)
    at Module._compile (module.js:541:32)
    at loader (/home/travis/build/namikingsoft/flowtype-sandbox/node_modules/babel-register/lib/node.js:158:5)
    at Object.require.extensions.(anonymous function) [as .js] (/home/travis/build/namikingsoft/flowtype-sandbox/node_modules/babel-register/lib/node.js:168:7)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Module.require (module.js:466:17)
    at require (internal/module.js:20:19)
    at /home/travis/build/namikingsoft/flowtype-sandbox/node_modules/mocha/bin/_mocha:310:3
    at Array.forEach (native)
    at Object.<anonymous> (/home/travis/build/namikingsoft/flowtype-sandbox/node_modules/mocha/bin/_mocha:309:10)
    at Module._compile (module.js:541:32)
    at Object.Module._extensions..js (module.js:550:10)
    at Module.load (module.js:456:32)
    at tryModuleLoad (module.js:415:12)
    at Function.Module._load (module.js:407:3)
    at Function.Module.runMain (module.js:575:10)
    at startup (node.js:159:18)
    at node.js:444:3 errno: -2, code: 'ENOENT', syscall: 'open', path: '.env' }
```
### やったこと
- [x] `postinstall`時に空の`.env`ファイルを作成
