### PR TITLE
TravisCIバッチがリンク切れしていたので修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Flow-type Sandbox [![Build Status][travis-badge]][travis-url]
 ==============================
 
-[travis-badge]: https://travis-ci.org/namikingsoft/flowtype-sandbox?branch=master
+[travis-badge]: https://travis-ci.org/namikingsoft/flowtype-sandbox.svg?branch=master
 [travis-url]: https://travis-ci.org/namikingsoft/flowtype-sandbox


### PR DESCRIPTION
GitHub管理画面からの直接修正。(便利な時代になったもんだね)
