### PR TITLE
ベースの値オブジェクトクラスを実装

### DIFF
--- a/src/utils/SingleValue.js
+++ b/src/utils/SingleValue.js
@@ -1,0 +1,21 @@
+// @flow
+
+export default class SingleValue<T> {
+  static privates: WeakMap<SingleValue, T> = new WeakMap();
+
+  constructor(value: T) {
+    SingleValue.privates.set(this, value)
+  }
+
+  valueOf(): T {
+    return SingleValue.privates.get(this)
+  }
+
+  toString(): string {
+    return String(this.valueOf())
+  }
+
+  equals(target: SingleValue<T>): boolean {
+    return this.valueOf() === target.valueOf()
+  }
+}

--- a/test/utils/SingleValue.spec.js
+++ b/test/utils/SingleValue.spec.js
@@ -1,0 +1,39 @@
+// @flow
+import assert from "power-assert"
+import SingleValue from "utils/SingleValue"
+
+describe("SingleValue", () => {
+  let single: SingleValue<number>
+
+  before(() => {
+    single = new SingleValue(1234)
+  })
+
+  describe("new", () => {
+    it("should be return new instance", () => {
+      assert(single instanceof SingleValue)
+    })
+  })
+
+  describe("valueOf", () => {
+    it("should be return initial value", () => {
+      assert(single.valueOf() === 1234)
+    })
+  })
+
+  describe("toString", () => {
+    it("should be return initial value to String", () => {
+      assert(single.toString() === "1234")
+    })
+  })
+
+  describe("equals", () => {
+    it("should be return initial value to String", () => {
+      const yes = (new SingleValue(1234): SingleValue<number>)
+      const no = (new SingleValue(12345): SingleValue<number>)
+      assert(single.equals(yes))
+      assert(!single.equals(no))
+      assert(single !== yes)
+    })
+  })
+})


### PR DESCRIPTION
値が一つしかない値オブジェクトに継承するようの便利クラスの実装。
### やったこと
- [x] ベースの値オブジェクトクラスを実装
- [x] ベースの値オブジェクトクラスのテスト
