### PR TITLE
Qiita記事のコンテンツ内容を値オブジェクト化する

### DIFF
--- a/src/domains/QiitaBody.js
+++ b/src/domains/QiitaBody.js
@@ -1,0 +1,5 @@
+// @flow
+import SingleValue from "utils/SingleValue"
+
+export default class QiitaBody extends SingleValue<string> {
+}

--- a/src/domains/QiitaFactory.js
+++ b/src/domains/QiitaFactory.js
@@ -1,5 +1,6 @@
 // @flow
 import QiitaItem from "domains/QiitaItem"
+import QiitaBody from "domains/QiitaBody"
 import type { ItemObject } from "types/QiitaType"
 
 export default class QiitaFactory {
@@ -7,8 +8,7 @@ export default class QiitaFactory {
   static createItem(row: ItemObject): QiitaItem {
     return new QiitaItem({
       title: row.title || "",
-      body: row.body || "",
-      user: row.user.id || "",
+      body: new QiitaBody(row.body || ""),
     })
   }
 }

--- a/src/domains/QiitaItem.js
+++ b/src/domains/QiitaItem.js
@@ -1,8 +1,9 @@
 // @flow
+import QiitaBody from "domains/QiitaBody"
+
 export type Param = {
   title: string,
-  body: string,
-  user: string,
+  body: QiitaBody,
 }
 
 export default class QiitaItem {
@@ -16,19 +17,14 @@ export default class QiitaItem {
     return QiitaItem.privates.get(this).title
   }
 
-  body(): string {
+  body(): QiitaBody {
     return QiitaItem.privates.get(this).body
-  }
-
-  user(): string {
-    return QiitaItem.privates.get(this).user
   }
 
   toObject(): Object {
     return {
       title: this.title(),
-      body: this.body(),
-      user: this.user(),
+      body: this.body().valueOf(),
     }
   }
 }

--- a/src/types/QiitaType.js
+++ b/src/types/QiitaType.js
@@ -1,9 +1,9 @@
 // @flow
 
 export type ItemObject = {
-  title: string,
-  body: string,
-  user: {
+  title?: string,
+  body?: string,
+  user?: {
     id: string,
   },
 }

--- a/test/domains/QiitaBody.spec.js
+++ b/test/domains/QiitaBody.spec.js
@@ -1,0 +1,17 @@
+// @flow
+import assert from "power-assert"
+import QiitaBody from "domains/QiitaBody"
+
+describe("QiitaBody", () => {
+  let body: QiitaBody
+
+  before(() => {
+    body = new QiitaBody("Body")
+  })
+
+  describe("new", () => {
+    it("should be return new instance", () => {
+      assert(body instanceof QiitaBody)
+    })
+  })
+})

--- a/test/domains/QiitaFactory.spec.js
+++ b/test/domains/QiitaFactory.spec.js
@@ -8,9 +8,6 @@ describe("QiitaFactory", () => {
     const item = QiitaFactory.createItem({
       title: "Title",
       body: "Body",
-      user: {
-        id: "User",
-      },
     })
     it("should be return new instance of QiitaItem", () => {
       assert(item instanceof QiitaItem)
@@ -19,7 +16,6 @@ describe("QiitaFactory", () => {
       assert.deepEqual(item.toObject(), {
         title: "Title",
         body: "Body",
-        user: "User",
       })
     })
   })

--- a/test/domains/QiitaItem.spec.js
+++ b/test/domains/QiitaItem.spec.js
@@ -1,16 +1,17 @@
 /* @flow */
 import assert from "power-assert"
 import QiitaItem from "domains/QiitaItem"
+import QiitaBody from "domains/QiitaBody"
 
 describe("QiitaItem", () => {
   let item: QiitaItem
+  let body: QiitaBody
+  let title: string
 
   beforeEach(() => {
-    item = new QiitaItem({
-      title: "Title",
-      body: "Body",
-      user: "User",
-    })
+    title = "Title"
+    body = new QiitaBody("Body")
+    item = new QiitaItem({ title, body })
   })
 
   describe("new", () => {
@@ -21,19 +22,13 @@ describe("QiitaItem", () => {
 
   describe("title", () => {
     it("should be return initial value", () => {
-      assert(item.title() === "Title")
+      assert(item.title() === title)
     })
   })
 
   describe("body", () => {
     it("should be return initial value", () => {
-      assert(item.body() === "Body")
-    })
-  })
-
-  describe("user", () => {
-    it("should be return initial value", () => {
-      assert(item.user() === "User")
+      assert(item.body() === body)
     })
   })
 
@@ -42,7 +37,6 @@ describe("QiitaItem", () => {
       assert.deepEqual(item.toObject(), {
         title: "Title",
         body: "Body",
-        user: "User",
       })
     })
   })

--- a/test/domains/QiitaRepository.spec.js
+++ b/test/domains/QiitaRepository.spec.js
@@ -19,12 +19,10 @@ describe("QiitaRepository", () => {
       {
         title: "Title1",
         body: "Body1",
-        user: { id: "User1" },
       },
       {
         title: "Title2",
         body: "Body2",
-        user: { id: "User2" },
       },
     ]
     nock("https://feedforce.qiita.com")
@@ -52,12 +50,10 @@ describe("QiitaRepository", () => {
         assert.deepEqual(posts[0].toObject(), {
           title: "Title1",
           body: "Body1",
-          user: "User1",
         })
         assert.deepEqual(posts[1].toObject(), {
           title: "Title2",
           body: "Body2",
-          user: "User2",
         })
       } catch (err) {
         assert.fail()


### PR DESCRIPTION
### やったこと
- [x] Qiita記事のコンテンツ内容の値オブジェクトを実装
- [x] Qiita記事エンティティに値オブジェクトを組み込む
- [x] Qiita記事エンティティからユーザーを削除 (今は使わないので)
